### PR TITLE
add a note to remove the torch.distributed emulation

### DIFF
--- a/gpt_j_deepspeed.py
+++ b/gpt_j_deepspeed.py
@@ -1,4 +1,6 @@
 import os
+# Important: the following env vars is a hack to emulated distributed environment on a single GPU. Remove all of the env vars if you run 
+# with more than one GPU and the torch.distributed or the deepspeed launcher
 os.environ['MASTER_ADDR'] = 'localhost'
 os.environ['MASTER_PORT'] = '9994'
 os.environ['RANK'] = "0"


### PR DESCRIPTION
it looks like users try to run this example on torch.distributed with multiple gpus and of course it fails. 

So I'm proposing to please at least add a note to remove the torch.distributed emulation hack for when multi-gpu setup is used.

Please feel free to edit the wording to your liking

Thank you!